### PR TITLE
Add configuration option for LdapAttributeStore

### DIFF
--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -15,6 +15,9 @@ config:
   idp_identifiers:
     - eppn
   ldap_identifier_attribute: uid
+  # Whether to clear values for attributes incoming
+  # to this microservice. Default is no or false.
+  clear_input_attributes: no
   # Configuration may also be done per-SP with any
   # missing parameters taken from the default if any.
   # The configuration key is the entityID of the SP.


### PR DESCRIPTION
Added the configuration option clear_input_attributes for the
LdapAttributeStore microservice. If yes or true attribute values
on input to the microservice are cleared. Default is no or false.