### PR TITLE
Always wrap metadata in single <EntityDescriptor> element

### DIFF
--- a/src/satosa/scripts/satosa_saml_metadata.py
+++ b/src/satosa/scripts/satosa_saml_metadata.py
@@ -29,7 +29,8 @@ def _create_split_entity_descriptors(entities, secc, valid):
 def _create_merged_entities_descriptors(entities, secc, valid, name):
     output = []
     frontend_entity_descriptors = [e for sublist in entities.values() for e in sublist]
-    output.append((create_signed_entities_descriptor(frontend_entity_descriptors, secc, valid), name))
+    for frontend in frontend_entity_descriptors:
+        output.append((create_signed_entity_descriptor(frontend, secc, valid), name))
 
     return output
 


### PR DESCRIPTION
Solves #81 . 

Since there is only one entity descriptor per file (irrespectively of merged or splitted metadata) there never should be a wrapping `<EntitiesDescriptor>`. According to [the spec](https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf), the Root element must be `<EntityDescriptor>`