### PR TITLE
Fix for #86

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -135,9 +135,10 @@ class SATOSABase(object):
         internal_attributes = internal_response.attributes
         for attribute in hash_attributes:
             # hash all attribute values individually
-            hashed_values = [UserIdHasher.hash_data(self.config["USER_ID_HASH_SALT"], v)
+            if attribute in internal_attributes:
+                hashed_values = [UserIdHasher.hash_data(self.config["USER_ID_HASH_SALT"], v)
                              for v in internal_attributes[attribute]]
-            internal_attributes[attribute] = hashed_values
+                internal_attributes[attribute] = hashed_values
 
         # remove all session state
         context.request = None


### PR DESCRIPTION
Only attempt to hash the attribute value if we already have a value for it. 