### PR TITLE
make sign_assertion and sign_response configurable

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -221,7 +221,7 @@ provider will be preserved, and when using a OAuth or OpenID Connect backend, th
 **Example**
 
     config:
-        config: [...]
+        idp_config: [...]
         acr_mapping:
             "": default-LoA
             "https://accounts.google.com": LoA1
@@ -237,7 +237,7 @@ with entity id `"sp-entity-id1"`:
 
 ```yaml
 config:
-    config: [...]
+    idp_config: [...]
     custom_attribute_release:
         idp-entity-id1
             sp-entity-id1:
@@ -249,11 +249,34 @@ as the key in the dict. For instance in order to exclude givenName for any sp or
 
 ```yaml
 config:
-    config: [...]
+    idp_config: [...]
     custom_attribute_release:
         "default":
             "":
                 exclude: ["givenName"]
+
+#### Policy
+
+Some settings related to how a SAML response is formed can be overriden on a per-instance or a per-SP
+basis. This example summarizes the most common settings (hopefully self-explanatory) with their defaults:
+
+```yaml
+config:
+    idp_config:
+        service:
+            idp:
+                policy:
+                    default:
+                        sign_response: True
+                        sign_assertion: False
+                        sign_alg: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+                        digest_alg: "http://www.w3.org/2001/04/xmlenc#sha256"
+                    <sp entityID>:
+                        ... 
+
+Overrides per SP entityID is possible by using the entityID as a key instead of the "default" key
+in the yaml structure. The most specific key takes presedence. If no policy overrides are provided
+the defaults above are used.
             
 
 #### Backend
@@ -267,7 +290,7 @@ The SAML backend can indicate which *Name ID* format it wants by specifying the 
 
  ```yaml
  config:
-   config:
+   sp_config:
      service:
        sp:
         name_id_format: urn:oasis:names:tc:SAML:2.0:nameid-format:transient
@@ -279,7 +302,7 @@ parameter `disco_srv`, must be specified if the metadata given to the backend mo
 
 ```yaml
 config:
-  config: [...]
+  sp_config: [...]
     disco_srv: http://disco.example.com
 ```
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -6,7 +6,6 @@ import functools
 import json
 import logging
 from urllib.parse import urlparse
-from distutils.util import strtobool
 
 from saml2 import SAMLError, xmldsig
 from saml2.config import IdPConfig
@@ -291,15 +290,15 @@ class SAMLFrontend(FrontendModule):
         # assume saml2int defaults: sign response but not the assertion & allow override
         sign_assertion = False
         try:
-            sign_assertion = strtobool(self.config['idp_config']['service']['idp']['policy']['default']['sign_assertion'])
-            sign_assertion = strtobool(self.config['idp_config']['service']['idp']['policy'][resp_args['sp_entity_id']]['sign_assertion'])
+            sign_assertion = self.config['idp_config']['service']['idp']['policy']['default']['sign_assertion']
+            sign_assertion = self.config['idp_config']['service']['idp']['policy'][resp_args['sp_entity_id']]['sign_assertion']
         except (KeyError, AttributeError, ValueError):
             pass
 
         sign_response = True
         try:
-            sign_response = strtobool(self.config['idp_config']['service']['idp']['policy']['default']['sign_response'])
-            sign_response = strtobool(self.config['idp_config']['service']['idp']['policy'][resp_args['sp_entity_id']]['sign_response'])
+            sign_response = self.config['idp_config']['service']['idp']['policy']['default']['sign_response']
+            sign_response = self.config['idp_config']['service']['idp']['policy'][resp_args['sp_entity_id']]['sign_response']
         except (KeyError, AttributeError, ValueError):
             pass
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -290,7 +290,8 @@ class SAMLFrontend(FrontendModule):
                 'identity'      : ava,
                 'name_id'       : name_id,
                 'authn'         : auth_info,
-                'sign_response' : True
+                'sign_response' : True,
+                'sign_assertion': True
                 }
 
         # Add the SP details

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -6,6 +6,7 @@ import functools
 import json
 import logging
 from urllib.parse import urlparse
+from distutils.util import strtobool
 
 from saml2 import SAMLError, xmldsig
 from saml2.config import IdPConfig
@@ -287,13 +288,28 @@ class SAMLFrontend(FrontendModule):
 
         satosa_logging(logger, logging.DEBUG, "returning attributes %s" % json.dumps(ava), context.state)
 
+        # assume saml2int defaults: sign response but not the assertion & allow override
+        sign_assertion = False
+        try:
+            sign_assertion = strtobool(self.config['idp_config']['service']['idp']['policy']['default']['sign_assertion'])
+            sign_assertion = strtobool(self.config['idp_config']['service']['idp']['policy'][resp_args['sp_entity_id']]['sign_assertion'])
+        except (KeyError, AttributeError, ValueError):
+            pass
+
+        sign_response = True
+        try:
+            sign_response = strtobool(self.config['idp_config']['service']['idp']['policy']['default']['sign_response'])
+            sign_response = strtobool(self.config['idp_config']['service']['idp']['policy'][resp_args['sp_entity_id']]['sign_response'])
+        except (KeyError, AttributeError, ValueError):
+            pass
+
         # Construct arguments for method create_authn_response on IdP Server instance
         args = {
                 'identity'      : ava,
                 'name_id'       : name_id,
                 'authn'         : auth_info,
-                'sign_response' : True,
-                'sign_assertion': True
+                'sign_response' : sign_response,
+                'sign_assertion': sign_assertion
                 }
 
         # Add the SP details


### PR DESCRIPTION
The saml2int profile actually requires the Assertion to be signed in addition to the response. We might want to make this configurable maybe...? however the default should be saml2int right?