### PR TITLE
Fix for no Format in NameIDPolicy for SAML2 frontend

### DIFF
--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -188,7 +188,7 @@ class SAMLFrontend(FrontendModule):
         context.state[self.name] = self._create_state_data(context, idp.response_args(authn_req),
                                                            context.request.get("RelayState"))
 
-        if authn_req.name_id_policy:
+        if authn_req.name_id_policy and authn_req.name_id_policy.format:
             name_format = saml_name_id_format_to_hash_type(authn_req.name_id_policy.format)
         else:
             # default to name id format from metadata, or just transient name id


### PR DESCRIPTION
Fix for https://github.com/SUNET/SATOSA/issues/101

It is acceptable SAML2 to have an <AuthnRequest> with
a <NameIDPolicy> that includes the AllowCreate attribute but
that does not include the Format attribute. When the SAML2
frontend receives such a request it should default to the
metadata for the SP to determine which Format the SP requires.
Before this commit SATOSA would ignore the SP metadata in such
a case and use a transient format.