### PR TITLE
NameID input from attributes for LDAP attribute store

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -527,7 +527,8 @@ correct functionality.
 An identifier such as eduPersonPrincipalName asserted by an IdP can be used to look up a person record
 in an LDAP directory to find attributes to assert about the authenticated user to the SP. The identifier
 to consume from the IdP, the LDAP directory details, and the mapping of attributes found in the
-directory may all be confingured on a per-SP basis. To use the 
+directory may all be confingured on a per-SP basis. The input to use when hashing to create a 
+persistent NameID may also be obtained from attributes returned from the LDAP directory. To use the 
 LDAP microservice install the extra necessary dependencies with `pip install satosa[ldap]` and then see the 
 [example config](../example/plugins/microservices/ldap_attribute_store.yaml.example).
 

--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -18,6 +18,10 @@ config:
   # Whether to clear values for attributes incoming
   # to this microservice. Default is no or false.
   clear_input_attributes: no
+  # List of LDAP attributes to use as input to hashing to create
+  # NameID.
+  user_id_from_attrs:
+    - employeeNumber
   # Configuration may also be done per-SP with any
   # missing parameters taken from the default if any.
   # The configuration key is the entityID of the SP.
@@ -26,3 +30,5 @@ config:
   https://sp.myserver.edu/shibboleth-sp
     search_base: ou=People,o=MyVO,dc=example,dc=org
     eduPersonPrincipalName: employeenumber
+    user_id_from_attrs:
+      - uid


### PR DESCRIPTION
Add functionality to specify that attributes returned from
the LDAP directory server used with the LDAP attribute store
should be used as input to be hashed for the NameID for a
persistent name identifier sent to a SP.