### PR TITLE
Idp identifier

### DIFF
--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -13,7 +13,24 @@ config:
     employeeNumber: employeenumber
     isMemberOf: ismemberof
   idp_identifiers:
+    # Ordered list of identifiers asserted as attributes by
+    # IdP to use when constructing search filter to find
+    # user record in LDAP directory. This example searches
+    # in order for eduPersonUniqueId, eduPersonPrincipalName
+    # combined with SAML persistent, eduPersonPrincipalName
+    # combined with eduPersonTargetedId,
+    # eduPersonPrincipalName, SAML persistent, and 
+    # eduPersonTargetedId.
+    - epuid
+    - 
+      - eppn
+      - name_id: urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+    -
+      - eppn
+      - edupersontargetedid
     - eppn
+    - name_id: urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+    - edupersontargetedid
   ldap_identifier_attribute: uid
   # Whether to clear values for attributes incoming
   # to this microservice. Default is no or false.


### PR DESCRIPTION
Enhanced the logic to take identifiers asserted by the IdP as attributes and use them to construct an ordered list of search filters to use when querying the LDAP directory to find the user record. Attribute values may now be concatenated and SAML2 NameID values may also be used.