### PR TITLE
Expose metadata endpoint via configuration option

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -15,6 +15,7 @@ from saml2.config import SPConfig
 from saml2.extension.ui import NAMESPACE as UI_NAMESPACE
 from saml2.metadata import create_metadata_string
 
+from satosa.base import SAMLBaseModule
 from .base import BackendModule
 from ..exception import SATOSAAuthenticationError
 from ..internal_data import (InternalResponse,
@@ -29,7 +30,7 @@ from ..util import rndstr
 logger = logging.getLogger(__name__)
 
 
-class SAMLBackend(BackendModule):
+class SAMLBackend(BackendModule, SAMLBaseModule):
     """
     A saml2 backend module (acting as a SP).
     """
@@ -51,7 +52,6 @@ class SAMLBackend(BackendModule):
         :param name: name of the plugin
         """
         super().__init__(outgoing, internal_attributes, base_url, name)
-
         sp_config = SPConfig().load(copy.deepcopy(config["sp_config"]), False)
         self.sp = Base(sp_config)
 
@@ -218,7 +218,7 @@ class SAMLBackend(BackendModule):
 
         internal_resp.user_id = response.get_subject().text
         internal_resp.attributes = self.converter.to_internal(self.attribute_profile, response.ava)
-        
+
         # The SAML response may not include a NameID
         try:
             internal_resp.name_id = response.assertion.subject.name_id
@@ -259,6 +259,11 @@ class SAMLBackend(BackendModule):
                 parsed_endp = urlparse(endp)
                 url_map.append(
                     ("^%s$" % parsed_endp.path[1:], self.disco_response))
+
+        if self.expose_entityid_endpoint():
+            parsed_entity_id = urlparse(self.sp.config.entityid)
+            url_map.append(("^{0}".format(parsed_entity_id.path[1:]),
+                            self._metadata_endpoint))
 
         return url_map
 
@@ -324,7 +329,7 @@ class SAMLBackend(BackendModule):
 
 class SAMLInternalResponse(InternalResponse):
     """
-    Like the parent InternalResponse, holds internal representation of 
+    Like the parent InternalResponse, holds internal representation of
     service related data, but includes additional details relevant to
     SAML interoperability.
 

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -266,3 +266,11 @@ class SATOSABase(object):
                            exc_info=True)
             raise SATOSAUnknownError("Unknown error") from err
         return resp
+
+
+class SAMLBaseModule(object):
+    KEY_ENTITYID_ENDPOINT = 'entityid_endpoint'
+
+    def expose_entityid_endpoint(self):
+        value = self.config.get(self.KEY_ENTITYID_ENDPOINT, False)
+        return bool(value)

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -15,6 +15,7 @@ from saml2.saml import NameID, NAMEID_FORMAT_TRANSIENT, NAMEID_FORMAT_PERSISTENT
 from saml2.samlp import name_id_policy_from_string
 from saml2.server import Server
 
+from satosa.base import SAMLBaseModule
 from .base import FrontendModule
 from ..internal_data import InternalRequest, UserIdHashType
 from ..logging_util import satosa_logging
@@ -57,7 +58,7 @@ def hash_type_to_saml_name_id_format(hash_type):
     return NAMEID_FORMAT_PERSISTENT
 
 
-class SAMLFrontend(FrontendModule):
+class SAMLFrontend(FrontendModule, SAMLBaseModule):
     """
     A pysaml2 frontend module
     """
@@ -410,6 +411,11 @@ class SAMLFrontend(FrontendModule):
                 parsed_endp = urlparse(endp)
                 url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
                                 functools.partial(self.handle_authn_request, binding_in=binding)))
+
+        if self.expose_entityid_endpoint():
+            parsed_entity_id = urlparse(self.idp.config.entityid)
+            url_map.append(("^{0}".format(parsed_entity_id.path[1:]),
+                            self._metadata_endpoint))
 
         return url_map
 


### PR DESCRIPTION
Check for configuration option `entityid_endpoint`.
When set to `true` the metadata will be served at the URL pointed by the entityid URI.

This commit introduces a new class `SAMLBaseModule` which serves as a common place for both frontend and backend _saml modules_. 

An example configuration would be:
```
module: satosa.backends.saml2.SAMLBackend
name: Saml2
config:
  entityid_endpoint: true
  sp_config:
    entityid: <base_url>/<name>/proxy_saml2_backend.xml
    ...
```