### PR TITLE
Correctly handle error responses

### DIFF
--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -129,7 +129,14 @@ class OpenIDConnectFrontend(FrontendModule):
         :rtype: oic.utils.http_util.Response
         """
         auth_req = self._get_authn_request_from_state(exception.state)
-        error_resp = AuthorizationErrorResponse(error="access_denied", error_description=exception.message)
+        # If the client sent us a state parameter, we should reflect it back according to the spec
+        if 'state' in auth_req: 
+            error_resp = AuthorizationErrorResponse(error="access_denied",
+                                                    error_description=exception.message,
+                                                    state=auth_req['state'])
+        else:                                           
+            error_resp = AuthorizationErrorResponse(error="access_denied", 
+                                                    error_description=exception.message)
         satosa_logging(logger, logging.DEBUG, exception.message, exception.state)
         return SeeOther(error_resp.request(auth_req["redirect_uri"], should_fragment_encode(auth_req)))
 


### PR DESCRIPTION
In case of an error, reflect the state to the client in the error
response (if the client sent a state parameter in the original
request)

http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthError
https://tools.ietf.org/html/rfc6749#section-4.2.2.1