### PR TITLE
Select preferred binding on the configuration

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -8,8 +8,6 @@ import logging
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from urllib.parse import urlparse
 
-from saml2 import BINDING_HTTP_POST
-from saml2 import BINDING_HTTP_REDIRECT
 from saml2.client_base import Base
 from saml2.config import SPConfig
 from saml2.extension.ui import NAMESPACE as UI_NAMESPACE
@@ -57,7 +55,6 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         self.config = config
         self.attribute_profile = config.get("attribute_profile", "saml")
-        self.bindings = [BINDING_HTTP_REDIRECT, BINDING_HTTP_POST]
         self.discosrv = config.get("disco_srv")
         self.encryption_keys = []
         self.outstanding_queries = {}
@@ -126,8 +123,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         :return: response to the user agent
         """
         try:
-            binding, destination = self.sp.pick_binding("single_sign_on_service", self.bindings, "idpsso",
-                                                        entity_id=entity_id)
+            binding, destination = self.sp.pick_binding(
+                "single_sign_on_service", None, "idpsso", entity_id=entity_id)
             satosa_logging(logger, logging.DEBUG, "binding: %s, destination: %s" % (binding, destination),
                            context.state)
             acs_endp, response_binding = self.sp.config.getattr("endpoints", "sp")["assertion_consumer_service"][0]


### PR DESCRIPTION
`pysaml2` supports the configuration option `preferred_binding` which is a map of services to array of preferred bindings for that service. Use the configuration instead of the currently hardcoded choices.

An example configuration would be the following:

```
  module: satosa.backends.saml2.SAMLBackend
  name: Saml2
  config:
    sp_config:
      preferred_binding:
        single_sign_on_service:
        - urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect
        - urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
```

This defines the preferred bindings for the SSO service, and is equivalent the code that was hardcoded before that is also the default behaviour of `pysaml2`. Changing the order of the bindings would use `HTTP-POST` instead of the `HTTP-Redirect`.

You can [see the preferred_binding service names map here](https://github.com/rohe/pysaml2/blob/master/src/saml2/config.py#L139-L156):
https://github.com/rohe/pysaml2/blob/master/src/saml2/config.py#L139-L156