### PR TITLE
Allow testers to run specific tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ envlist=py34,py35
 
 [testenv]
 deps=-rtests/test_requirements.txt
-
-commands=py.test tests/
+commands = py.test {posargs:tests/}
 
 [pep8]
 max-line-length=100


### PR DESCRIPTION
Until now the command 'tox' would run all of the tests.
With this change one can specify a test to be run by running:

    tox -- path/to/test.py