### PR TITLE
Fix default values for acr

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -33,8 +33,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
     """
     A saml2 backend module (acting as a SP).
     """
-    VALUE_ACR_CLASS_REF_DEFAULT = 'http://eidas.europa.eu/LoA/low'
-    VALUE_ACR_COMPARISON_DEFAULT = 'minimum'
+    VALUE_ACR_COMPARISON_DEFAULT = 'exact'
 
     def __init__(self, outgoing, internal_attributes, config, base_url, name):
         """
@@ -129,8 +128,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             }
 
         authn_context = requested_authn_context(
-            acr_entry.get('class_ref', self.VALUE_ACR_CLASS_REF_DEFAULT),
-            comparison=acr_entry.get(
+            acr_entry['class_ref'], comparison=acr_entry.get(
                 'comparison', self.VALUE_ACR_COMPARISON_DEFAULT))
 
         return authn_context


### PR DESCRIPTION
The previous PR was merged too quickly to notice this. 
- Firstly, the default `Comparison` value for SAML2int should be _exact_.
- Secondly, as I discussed with @jkakavas , it does not make much sense to have a default `class_ref` value. It is the vital part of the `acr_mapping` configuration and it is mandatory that it is provided. If no value for `class_ref` is given this should fail by producing a `KeyError` exception. 