### PR TITLE
Feature refactor saml modules

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -55,14 +55,12 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         :param name: name of the plugin
         """
         super().__init__(outgoing, internal_attributes, base_url, name)
-        self.config = config
-        self.init_attribute_profile()
+        self.config = self.init_config(config)
 
         sp_config = SPConfig().load(copy.deepcopy(config[self.KEY_SP_CONFIG]), False)
         self.sp = Base(sp_config)
 
         self.discosrv = config.get(self.KEY_DISCO_SRV)
-        self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
         self.encryption_keys = []
         self.outstanding_queries = {}
 

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -26,6 +26,7 @@ from ..metadata_creation.description import (MetadataDescription, OrganizationDe
 from ..response import SeeOther, Response
 from ..saml_util import make_saml_response
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +60,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         self.sp = Base(sp_config)
 
         self.discosrv = config.get("disco_srv")
-        self.acr_mapping = config.get("acr_mapping")
+        self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
         self.encryption_keys = []
         self.outstanding_queries = {}
 

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -34,6 +34,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
     """
     A saml2 backend module (acting as a SP).
     """
+    KEY_DISCO_SRV = 'disco_srv'
     VALUE_ACR_COMPARISON_DEFAULT = 'exact'
 
     def __init__(self, outgoing, internal_attributes, config, base_url, name):
@@ -59,7 +60,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         sp_config = SPConfig().load(copy.deepcopy(config["sp_config"]), False)
         self.sp = Base(sp_config)
 
-        self.discosrv = config.get("disco_srv")
+        self.discosrv = config.get(self.KEY_DISCO_SRV)
         self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
         self.encryption_keys = []
         self.outstanding_queries = {}

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -275,11 +275,13 @@ class SAMLBaseModule(object):
     KEY_ACR_MAPPING = 'acr_mapping'
     VALUE_ATTRIBUTE_PROFILE_DEFAULT = 'saml'
 
+    def init_config(self, config):
+        self.attribute_profile = config.get(
+            self.KEY_ATTRIBUTE_PROFILE,
+            self.VALUE_ATTRIBUTE_PROFILE_DEFAULT)
+        self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
+        return config
+
     def expose_entityid_endpoint(self):
         value = self.config.get(self.KEY_ENTITYID_ENDPOINT, False)
         return bool(value)
-
-    def init_attribute_profile(self):
-        self.attribute_profile = self.config.get(
-            self.KEY_ATTRIBUTE_PROFILE,
-            self.VALUE_ATTRIBUTE_PROFILE_DEFAULT)

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -18,6 +18,7 @@ from .plugin_loader import load_request_microservices, load_response_microservic
 from .routing import ModuleRouter, SATOSANoBoundEndpointError
 from .state import cookie_to_state, SATOSAStateError, State, state_to_cookie
 
+
 logger = logging.getLogger(__name__)
 
 STATE_KEY = "SATOSA_BASE"
@@ -271,6 +272,7 @@ class SATOSABase(object):
 class SAMLBaseModule(object):
     KEY_ENTITYID_ENDPOINT = 'entityid_endpoint'
     KEY_ATTRIBUTE_PROFILE = 'attribute_profile'
+    KEY_ACR_MAPPING = 'acr_mapping'
     VALUE_ATTRIBUTE_PROFILE_DEFAULT = 'saml'
 
     def expose_entityid_endpoint(self):

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -62,6 +62,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
     """
     A pysaml2 frontend module
     """
+    KEY_CUSTOM_ATTR_RELEASE = 'custom_attribute_release'
 
     def __init__(self, auth_req_callback_func, internal_attributes, config, base_url, name):
         self._validate_config(config)
@@ -72,7 +73,8 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
 
         self.endpoints = config["endpoints"]
         self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
-        self.custom_attribute_release = config.get("custom_attribute_release")
+        self.custom_attribute_release = config.get(
+            self.KEY_CUSTOM_ATTR_RELEASE)
         self.idp = None
 
     def handle_authn_response(self, context, internal_response):

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -63,6 +63,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
     A pysaml2 frontend module
     """
     KEY_CUSTOM_ATTR_RELEASE = 'custom_attribute_release'
+    KEY_ENDPOINTS = 'endpoints'
 
     def __init__(self, auth_req_callback_func, internal_attributes, config, base_url, name):
         self._validate_config(config)
@@ -71,7 +72,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         self.config = config
         self.init_attribute_profile()
 
-        self.endpoints = config["endpoints"]
+        self.endpoints = config[self.KEY_ENDPOINTS]
         self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
         self.custom_attribute_release = config.get(
             self.KEY_CUSTOM_ATTR_RELEASE)
@@ -161,7 +162,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         if not config:
             raise ValueError("conf can't be 'None'")
 
-        for key in {"idp_config", "endpoints"}:
+        for key in {"idp_config", self.KEY_ENDPOINTS}:
             if key not in config:
                 raise ValueError("Missing key '%s' in config" % key)
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -71,11 +71,9 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         self._validate_config(config)
 
         super().__init__(auth_req_callback_func, internal_attributes, base_url, name)
-        self.config = config
-        self.init_attribute_profile()
+        self.config = self.init_config(config)
 
         self.endpoints = config[self.KEY_ENDPOINTS]
-        self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
         self.custom_attribute_release = config.get(
             self.KEY_CUSTOM_ATTR_RELEASE)
         self.idp = None

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -22,7 +22,8 @@ from ..logging_util import satosa_logging
 from ..response import Response
 from ..response import ServiceError
 from ..saml_util import make_saml_response
-from ..util import get_dict_defaults
+import satosa.util as util
+
 
 logger = logging.getLogger(__name__)
 
@@ -277,29 +278,38 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         request_state = self.load_state(context.state)
 
         resp_args = request_state["resp_args"]
-        internal_response.attributes = self._filter_attributes(idp, internal_response, context)
-        ava = self.converter.from_internal(self.attribute_profile, internal_response.attributes)
+        sp_entity_id = resp_args["sp_entity_id"]
+        internal_response.attributes = self._filter_attributes(
+            idp, internal_response, context)
+        ava = self.converter.from_internal(
+            self.attribute_profile, internal_response.attributes)
 
         auth_info = {}
         if self.acr_mapping:
-            auth_info["class_ref"] = self.acr_mapping.get(internal_response.auth_info.issuer, self.acr_mapping[""])
+            auth_info["class_ref"] = self.acr_mapping.get(
+                internal_response.auth_info.issuer, self.acr_mapping[""])
         else:
             auth_info["class_ref"] = internal_response.auth_info.auth_class_ref
 
         auth_info["authn_auth"] = internal_response.auth_info.issuer
 
         if self.custom_attribute_release:
-            custom_release = get_dict_defaults(self.custom_attribute_release, internal_response.auth_info.issuer, resp_args["sp_entity_id"])
+            custom_release = util.get_dict_defaults(
+                self.custom_attribute_release,
+                internal_response.auth_info.issuer,
+                sp_entity_id)
             attributes_to_remove = custom_release.get("exclude", [])
             for k in attributes_to_remove:
                 ava.pop(k, None)
 
         name_id = NameID(text=internal_response.user_id,
-                         format=hash_type_to_saml_name_id_format(internal_response.user_id_hash_type),
+                         format=hash_type_to_saml_name_id_format(
+                             internal_response.user_id_hash_type),
                          sp_name_qualifier=None,
                          name_qualifier=None)
 
-        satosa_logging(logger, logging.DEBUG, "returning attributes %s" % json.dumps(ava), context.state)
+        dbgmsg = "returning attributes %s" % json.dumps(ava)
+        satosa_logging(logger, logging.DEBUG, dbgmsg, context.state)
 
         # assume saml2int defaults: sign response but not the assertion & allow override
         sign_assertion = False
@@ -322,14 +332,15 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         except (KeyError, AttributeError, ValueError):
             pass
 
-        # Construct arguments for method create_authn_response on IdP Server instance
+        # Construct arguments for method create_authn_response
+        # on IdP Server instance
         args = {
-                'identity'      : ava,
-                'name_id'       : name_id,
-                'authn'         : auth_info,
-                'sign_response' : sign_response,
-                'sign_assertion': sign_assertion
-                }
+            'identity'      : ava,
+            'name_id'       : name_id,
+            'authn'         : auth_info,
+            'sign_response' : sign_response,
+            'sign_assertion': sign_assertion,
+        }
 
         # Add the SP details
         args.update(**resp_args)
@@ -358,12 +369,16 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         except (KeyError, AttributeError):
             pass
 
-        satosa_logging(logger, logging.DEBUG, "signing with algorithm %s" % args['sign_alg'], context.state)
-        satosa_logging(logger, logging.DEBUG, "using digest algorithm %s" % args['digest_alg'], context.state)
+        for dbgmsg in [
+            "signing with algorithm %s" % args['sign_alg'],
+            "using digest algorithm %s" % args['digest_alg'],
+        ]:
+            satosa_logging(logger, logging.DEBUG, dbgmsg, context.state)
 
         resp = idp.create_authn_response(**args)
-        http_args = idp.apply_binding(resp_args["binding"], str(resp), resp_args["destination"],
-                                      request_state["relay_state"], response=True)
+        http_args = idp.apply_binding(
+            resp_args["binding"], str(resp), resp_args["destination"],
+            request_state["relay_state"], response=True)
         del context.state[self.name]
         return make_saml_response(resp_args["binding"], http_args)
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -161,12 +161,19 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         :type config: dict[str, dict[str, Any] | str]
         :param config: The module config
         """
-        if not config:
-            raise ValueError("conf can't be 'None'")
+        required_keys = [
+            self.KEY_IDP_CONFIG,
+            self.KEY_ENDPOINTS,
+        ]
 
-        for key in {self.KEY_IDP_CONFIG, self.KEY_ENDPOINTS}:
-            if key not in config:
-                raise ValueError("Missing key '%s' in config" % key)
+        if not config:
+            raise ValueError("No configuration given")
+
+        for key in required_keys:
+            try:
+                _val = config[key]
+            except KeyError as e:
+                raise ValueError("Missing configuration key: %s" % key) from e
 
     def _handle_authn_request(self, context, binding_in, idp):
         """

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -63,16 +63,16 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
     A pysaml2 frontend module
     """
 
-    def __init__(self, auth_req_callback_func, internal_attributes, conf, base_url, name):
-        self._validate_config(conf)
+    def __init__(self, auth_req_callback_func, internal_attributes, config, base_url, name):
+        self._validate_config(config)
 
         super().__init__(auth_req_callback_func, internal_attributes, base_url, name)
-        self.config = conf
+        self.config = config
         self.init_attribute_profile()
 
-        self.endpoints = conf["endpoints"]
-        self.acr_mapping = conf.get("acr_mapping")
-        self.custom_attribute_release = conf.get("custom_attribute_release")
+        self.endpoints = config["endpoints"]
+        self.acr_mapping = config.get("acr_mapping")
+        self.custom_attribute_release = config.get("custom_attribute_release")
         self.idp = None
 
     def handle_authn_response(self, context, internal_response):

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -71,7 +71,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         self.init_attribute_profile()
 
         self.endpoints = config["endpoints"]
-        self.acr_mapping = config.get("acr_mapping")
+        self.acr_mapping = config.get(self.KEY_ACR_MAPPING)
         self.custom_attribute_release = config.get("custom_attribute_release")
         self.idp = None
 


### PR DESCRIPTION
This changeset is a generic cleanup on the saml base, frontend and backend modules. 
I tried to make the code simpler and more readable, while avoiding repetition. 

The general idea is that configuration keys should not be magic values all over the code and thus should be defined in the modules that uses the keys. Initialisation of common keys in the front and back end are handled by the base module. 

While the changes may look a lot, most are formatting changes (whitespace, max line length, etc) and there are only a couple of actual code changes on how fallbacks are handled. 
These happen on backend's `__init__` regarding `key_file_paths` and on the frontend's `_handle_authn_response` function regarding how `policy` settings are accessed to gather info about `sign_assertion`, `sign_response`, `sign_alg` and `digest_alg`.

PS: It should be easier to look at each commit separately