### PR TITLE
Allow CMService to show additional information

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -103,13 +103,15 @@ class SATOSABase(object):
         state = context.state
         state[STATE_KEY] = {"requester": internal_request.requester}
         # TODO consent module should manage any state it needs by itself
-        if consent.STATE_KEY in context.state:
-            context.state[consent.STATE_KEY]["filter"] = internal_request.approved_attributes or []
-            context.state[consent.STATE_KEY]["requester_name"] = internal_request.requester_name
-        else:
-            context.state[consent.STATE_KEY] = {"filter": internal_request.approved_attributes or [],
-                                                "requester_name": internal_request.requester_name}
-
+        try:
+            state_dict = context.state[consent.STATE_KEY]
+        except KeyError:
+            state_dict = context.state[consent.STATE_KEY] = {}
+        finally:
+            state_dict.update({
+                "filter": internal_request.approved_attributes or [],
+                "requester_name": internal_request.requester_name,
+            })
         satosa_logging(logger, logging.INFO,
                        "Requesting provider: {}".format(internal_request.requester), state)
 

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -103,8 +103,13 @@ class SATOSABase(object):
         state = context.state
         state[STATE_KEY] = {"requester": internal_request.requester}
         # TODO consent module should manage any state it needs by itself
-        context.state[consent.STATE_KEY] = {"filter": internal_request.approved_attributes or [],
-                                            "requester_name": internal_request.requester_name}
+        if consent.STATE_KEY in context.state:
+            context.state[consent.STATE_KEY]["filter"] = internal_request.approved_attributes or []
+            context.state[consent.STATE_KEY]["requester_name"] = internal_request.requester_name
+        else:
+            context.state[consent.STATE_KEY] = {"filter": internal_request.approved_attributes or [],
+                                                "requester_name": internal_request.requester_name}
+
         satosa_logging(logger, logging.INFO,
                        "Requesting provider: {}".format(internal_request.requester), state)
 

--- a/src/satosa/micro_services/consent.py
+++ b/src/satosa/micro_services/consent.py
@@ -89,7 +89,8 @@ class Consent(ResponseMicroService):
         }
         if self.locked_attr:
             consent_args["locked_attrs"] = [self.locked_attr]
-
+        if 'requester_logo' in context.state[STATE_KEY]:
+             consent_args["requester_logo"] = context.state[STATE_KEY]['requester_logo']
         try:
             ticket = self._consent_registration(consent_args)
         except (ConnectionError, UnexpectedResponseError) as e:


### PR DESCRIPTION
If a logo url/path is available for the requester ( handling happens in the respective frontend ) , send that to the consent service so that it can be shown in the UI. 
This is a non breaking change, the use case comes from the InAcademia service. 