### PR TITLE
Draft of error handling functionality

### DIFF
--- a/src/satosa/exception.py
+++ b/src/satosa/exception.py
@@ -30,6 +30,39 @@ class SATOSACriticalError(SATOSAError):
     """
     pass
 
+class SATOSAProcessingHaltError(SATOSAError):
+    """
+    SATOSA error that should stop processing
+    """
+    def __init__(self, state, message, *args, **kwargs):
+        """
+        :type state: satosa.state.State
+        :param message: str
+        :param args: any
+        :param kwargs: any
+
+        :param state: Satosa state
+        :param message: A test message
+        :param args: whatever
+        :param kwargs: whatever
+        """
+        super().__init__(message, *args, **kwargs)
+        self._message = "One of the plugins or microservices raised an error. Redirect to an error page"
+        self.state = state.copy()
+        self.error_id = 0
+        if 'redirect_uri' in kwargs:
+            self.redirect_uri = kwargs['redirect_uri']
+        else:
+            self.redirect_uri = None
+
+    @property
+    def message(self):
+        """
+        :rtype: str
+        :return: Exception message
+        """
+        return self._message.format(error_id=self.error_id)
+
 
 class SATOSAUnknownError(SATOSAError):
     """


### PR DESCRIPTION
I'm opening this so that we can discuss it. I'll close this PR once the discussion is over and submit a clean one

The idea is that one can raise a `SATOSAProcessingHaltError` from any backend/frontend or microservice and that will cause SATOSA to stop executing and either redirect the user to a given url (external error service) 
```
raise SATOSAProcessingHaltError(redirect_uri="https://this.is.url")
```

or return a 500 with a message 

```
raise SATOSAProcessingHaltError("This is an error to be shown")
```

We should probably add support for some rudimentary  templating engine ( mako ) if we want to support local errors ( 5xx, 4xx ) instead of only redirects 

Ideas and feedback are welcome