### PR TITLE
add scope extractor processor

### DIFF
--- a/src/satosa/micro_services/processors/scope_extractor_processor.py
+++ b/src/satosa/micro_services/processors/scope_extractor_processor.py
@@ -28,7 +28,7 @@ class ScopeExtractorProcessor(BaseProcessor):
             raise AttributeProcessorError("The mapped_attribute needs to be set")
 
         attributes = internal_data.attributes
-        values = attributes.get(attribute, [None])
+        values = attributes.get(attribute, [])
         if not values:
             raise AttributeProcessorWarning("Cannot apply scope_extractor to {}, it has no values".format(attribute))
         if not any('@' in val for val in values):

--- a/src/satosa/micro_services/processors/scope_extractor_processor.py
+++ b/src/satosa/micro_services/processors/scope_extractor_processor.py
@@ -1,0 +1,35 @@
+from ..attribute_processor import AttributeProcessorError
+from .base_processor import BaseProcessor
+
+
+CONFIG_KEY_MAPPEDATTRIBUTE = 'mapped_attribute'
+CONFIG_DEFAULT_MAPPEDATTRIBUTE = ''
+
+
+class ScopeExtractorProcessor(BaseProcessor):
+    """
+    Extracts the scope from a scoped attribute and maps that to 
+    another attribute
+    
+    Example configuration:
+    module: satosa.micro_services.attribute_processor.AttributeProcessor
+    name: AttributeProcessor
+    config:
+      process:
+      - attribute: scoped_affiliation
+        processors:
+        - name: ScopeExtractorProcessor
+          module: satosa.micro_services.processors.scope_extractor_processor
+          mapped_attribute: domain
+    """
+    def process(self, internal_data, attribute, **kwargs):
+        mapped_attribute = kwargs.get(CONFIG_KEY_MAPPEDATTRIBUTE, CONFIG_DEFAULT_MAPPEDATTRIBUTE)
+        if mapped_attribute is None or mapped_attribute == '':
+            raise AttributeProcessorError("The mapped_attribute needs to be set")
+
+        attributes = internal_data.attributes
+        for value in attributes.get(attribute, [None]):
+            if '@' in value:
+                scope = value.split('@')[1]
+                attributes[mapped_attribute] = [scope]
+

--- a/src/satosa/micro_services/processors/scope_extractor_processor.py
+++ b/src/satosa/micro_services/processors/scope_extractor_processor.py
@@ -1,4 +1,4 @@
-from ..attribute_processor import AttributeProcessorError
+from ..attribute_processor import AttributeProcessorError, AttributeProcessorWarning
 from .base_processor import BaseProcessor
 
 
@@ -8,9 +8,9 @@ CONFIG_DEFAULT_MAPPEDATTRIBUTE = ''
 
 class ScopeExtractorProcessor(BaseProcessor):
     """
-    Extracts the scope from a scoped attribute and maps that to 
+    Extracts the scope from a scoped attribute and maps that to
     another attribute
-    
+
     Example configuration:
     module: satosa.micro_services.attribute_processor.AttributeProcessor
     name: AttributeProcessor
@@ -28,8 +28,13 @@ class ScopeExtractorProcessor(BaseProcessor):
             raise AttributeProcessorError("The mapped_attribute needs to be set")
 
         attributes = internal_data.attributes
-        for value in attributes.get(attribute, [None]):
+        values = attributes.get(attribute, [None])
+        if not values:
+            raise AttributeProcessorWarning("Cannot apply scope_extractor to {}, it has no values".format(attribute))
+        if not any('@' in val for val in values):
+            raise AttributeProcessorWarning("Cannot apply scope_extractor to {}, it's values are not scoped".format(attribute))
+        for value in values:
             if '@' in value:
                 scope = value.split('@')[1]
                 attributes[mapped_attribute] = [scope]
-
+                break


### PR DESCRIPTION
Processor to be used with the attribute_processor microservice. Allows to extract the scope from any scoped attribute and map that to another attribute