### PR TITLE
Fix userid handling for Github backend

### DIFF
--- a/src/satosa/backends/github.py
+++ b/src/satosa/backends/github.py
@@ -98,7 +98,7 @@ class GitHubBackend(_OAuthBackend):
         internal_response = InternalResponse(auth_info=auth_info)
         internal_response.attributes = self.converter.to_internal(
             self.external_type, user_info)
-        internal_response.user_id = user_info[self.user_id_attr]
+        internal_response.user_id = str(user_info[self.user_id_attr])
         del context.state[self.name]
         return self.auth_callback_func(context, internal_response)
 


### PR DESCRIPTION
According to the documentation, the id of the user is returned as an
integer (https://developer.github.com/v3/users/). We assume later on
that it is a string so cast it to str here