### PR TITLE
Allow AL internal UniqueID to be used as attribute

### DIFF
--- a/example/plugins/microservices/account_linking.yaml.example
+++ b/example/plugins/microservices/account_linking.yaml.example
@@ -4,3 +4,4 @@ config:
   api_url: "https://localhost:8167"
   redirect_url: "https://localhost:8167/approve"
   sign_key: "pki/account_linking.key"
+  id_to_attr: "uniqueid"

--- a/src/satosa/micro_services/account_linking.py
+++ b/src/satosa/micro_services/account_linking.py
@@ -52,6 +52,10 @@ class AccountLinking(ResponseMicroService):
             satosa_logging(logger, logging.INFO, "issuer/id pair is linked in AL service",
                            context.state)
             internal_response.user_id = message
+            id_to_attr = self.config.get("id_to_attr", None)
+            if id_to_attr:
+                internal_response.attributes[id_to_attr] = message
+
             del context.state[self.name]
             return super().process(context, internal_response)
         else:
@@ -76,6 +80,9 @@ class AccountLinking(ResponseMicroService):
             satosa_logging(logger, logging.INFO, "issuer/id pair is linked in AL service",
                            context.state)
             internal_response.user_id = message
+            id_to_attr = self.config.get("id_to_attr", None)
+            if id_to_attr:
+                internal_response.attributes[id_to_attr] = message
             try:
                 del context.state[self.name]
             except KeyError:

--- a/src/satosa/micro_services/account_linking.py
+++ b/src/satosa/micro_services/account_linking.py
@@ -32,6 +32,7 @@ class AccountLinking(ResponseMicroService):
         self.redirect_url = config["redirect_url"]
         self.signing_key = RSAKey(key=rsa_load(config["sign_key"]), use="sig", alg="RS256")
         self.endpoint = "/handle_account_linking"
+        self.config = config
         logger.info("Account linking is active")
 
     def _handle_al_response(self, context):

--- a/src/satosa/micro_services/account_linking.py
+++ b/src/satosa/micro_services/account_linking.py
@@ -32,7 +32,7 @@ class AccountLinking(ResponseMicroService):
         self.redirect_url = config["redirect_url"]
         self.signing_key = RSAKey(key=rsa_load(config["sign_key"]), use="sig", alg="RS256")
         self.endpoint = "/handle_account_linking"
-        self.config = config
+        self.id_to_attr = config.get("id_to_attr", None)
         logger.info("Account linking is active")
 
     def _handle_al_response(self, context):
@@ -53,9 +53,8 @@ class AccountLinking(ResponseMicroService):
             satosa_logging(logger, logging.INFO, "issuer/id pair is linked in AL service",
                            context.state)
             internal_response.user_id = message
-            id_to_attr = self.config.get("id_to_attr", None)
-            if id_to_attr:
-                internal_response.attributes[id_to_attr] = message
+            if self.id_to_attr:
+                internal_response.attributes[id_to_attr] = [message]
 
             del context.state[self.name]
             return super().process(context, internal_response)
@@ -81,9 +80,8 @@ class AccountLinking(ResponseMicroService):
             satosa_logging(logger, logging.INFO, "issuer/id pair is linked in AL service",
                            context.state)
             internal_response.user_id = message
-            id_to_attr = self.config.get("id_to_attr", None)
-            if id_to_attr:
-                internal_response.attributes[id_to_attr] = message
+            if self.id_to_attr:
+                internal_response.attributes[id_to_attr] = [message]
             try:
                 del context.state[self.name]
             except KeyError:


### PR DESCRIPTION
If configured, map AL internal unique id as an attribute to be used
by satosa, microservices and other plugins.