### PR TITLE
replace ENTRYPOINT with CMD; EXPOSE port; + apt-get clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,10 @@ RUN apt-get update && \
 RUN mkdir -p /src/satosa
 COPY . /src/satosa
 COPY docker/setup.sh /setup.sh
-RUN /setup.sh
-
 COPY docker/start.sh /start.sh
+RUN chmod +x /setup.sh /start.sh \
+ && /setup.sh
+
 COPY docker/attributemaps /opt/satosa/attributemaps
 
 VOLUME /opt/satosa/etc

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
     libffi-dev \
     libssl-dev \
     xmlsec1 \
-    libyaml-dev
+    libyaml-dev && \
+    apt-get clean
 
 RUN mkdir -p /src/satosa
 COPY . /src/satosa
@@ -21,4 +22,6 @@ COPY docker/start.sh /start.sh
 COPY docker/attributemaps /opt/satosa/attributemaps
 
 VOLUME /opt/satosa/etc
-ENTRYPOINT ["/start.sh"]
+CMD ["/start.sh"]
+ARG PROXY_PORT=8000
+EXPOSE $PROXY_PORT

--- a/scripts/start_proxy.py
+++ b/scripts/start_proxy.py
@@ -1,0 +1,12 @@
+import re
+import sys
+
+from gunicorn.app.wsgiapp import run
+
+print('\n'.join(sys.path))
+# use this entrypoint to start the proxy from the IDE
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(run())
+


### PR DESCRIPTION
* CMD allows `docker run`with a shell; ENTRYPOINT is not suiteable here.- 
* For Docker orchestration tools it is good practice to export ports.
* apt-get clean at the end of each run will make the layer lean.