### PR TITLE
Idp blacklisting

### DIFF
--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -1,6 +1,7 @@
 module: satosa.backends.saml2.SAMLBackend
 name: Saml2
 config:
+  idp_blacklist_file: /path/to/blacklist.json
   sp_config:
     key_file: backend.key
     cert_file: backend.crt
@@ -13,8 +14,6 @@ config:
       local: [idp.xml]
 
     entityid: <base_url>/<name>/proxy_saml2_backend.xml
-    idp_blacklist_enabled: true
-    idp_blacklist_file: /path/to/blacklist.json
     service:
       sp:
         want_response_signed: true

--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -13,6 +13,8 @@ config:
       local: [idp.xml]
 
     entityid: <base_url>/<name>/proxy_saml2_backend.xml
+    idp_blacklist_enabled: true
+    idp_blacklist_file: /path/to/blacklist.json
     service:
       sp:
         want_response_signed: true

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -63,6 +63,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         self.discosrv = config.get(self.KEY_DISCO_SRV)
         self.encryption_keys = []
         self.outstanding_queries = {}
+        self.idp_blacklist_file = config.get('idp_blacklist_file', None)
 
         sp_keypairs = sp_config.getattr('encryption_keypairs', '')
         sp_key_file = sp_config.getattr('key_file', '')
@@ -152,8 +153,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         # If IDP blacklisting is enabled and the selected IDP is blacklisted,
         # stop here
-        if self.config["sp_config"].get("idp_blacklist_enabled", None):
-            with open(self.config["sp_config"]["idp_blacklist_file"]) as blacklist_file:
+        if self.idp_blacklist_file:
+            with open(self.idp_blacklist_file) as blacklist_file:
                 blacklist_array = json.load(blacklist_file)['blacklist']
                 if entity_id in blacklist_array:
                     satosa_logging(logger, logging.DEBUG, "IdP with EntityID {} is blacklisted".format(entity_id), context.state, exc_info=False)

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -149,6 +149,17 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         :param entity_id: Target IDP entity id
         :return: response to the user agent
         """
+
+        # If IDP blacklisting is enabled and the selected IDP is blacklisted,
+        # stop here
+        if self.config["sp_config"]["idp_blacklist_enabled"]:
+            with open(self.config["sp_config"]["idp_blacklist_file"]) as blacklist_file:
+                blacklist_array = json.load(blacklist_file)['blacklist']
+                if entity_id in blacklist_array:
+            satosa_logging(logger, logging.DEBUG, "IdP with EntityID {} is blacklisted".format(entity_id), context.state,
+                           exc_info=False)
+            raise SATOSAAuthenticationError(context.state, "Selected IdP is blacklisted for this backend")
+
         kwargs = {}
         authn_context = self.construct_requested_authn_context(entity_id)
         if authn_context:

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -152,7 +152,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         # If IDP blacklisting is enabled and the selected IDP is blacklisted,
         # stop here
-        if self.config["sp_config"]["idp_blacklist_enabled"]:
+        if self.config["sp_config"].get("idp_blacklist_enabled", None):
             with open(self.config["sp_config"]["idp_blacklist_file"]) as blacklist_file:
                 blacklist_array = json.load(blacklist_file)['blacklist']
                 if entity_id in blacklist_array:

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -156,9 +156,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             with open(self.config["sp_config"]["idp_blacklist_file"]) as blacklist_file:
                 blacklist_array = json.load(blacklist_file)['blacklist']
                 if entity_id in blacklist_array:
-            satosa_logging(logger, logging.DEBUG, "IdP with EntityID {} is blacklisted".format(entity_id), context.state,
-                           exc_info=False)
-            raise SATOSAAuthenticationError(context.state, "Selected IdP is blacklisted for this backend")
+                    satosa_logging(logger, logging.DEBUG, "IdP with EntityID {} is blacklisted".format(entity_id), context.state, exc_info=False)
+                    raise SATOSAAuthenticationError(context.state, "Selected IdP is blacklisted for this backend")
 
         kwargs = {}
         authn_context = self.construct_requested_authn_context(entity_id)


### PR DESCRIPTION
This enables the SAML backend to define a list of blacklisted SAML IdPs that can't be used. If a user selects one of those, we return an error. 
The assumed format of the `idp_blacklist_file` is : 
```json
{"blacklist": [ "https://blacklisted_entityid1.org/saml/idp",
"https://blacklisted_entityid2.org/saml/idp",
"https://blacklisted_entityid3.org/saml/idp",
]}
```