### PR TITLE
Add support for reading OIDC clients from json formatted file

### DIFF
--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -2,7 +2,8 @@ module: satosa.frontends.openid_connect.OpenIDConnectFrontend
 name: OIDC
 config:
   signing_key_path: frontend.key
-  db_uri: mongodb://db.example.com # optional: only support MongoDB, will default to in-memory storage if not specified
+  db_uri: mongodb://db.example.com # optional: only support MongoDB, will default to in-memory storage if not specified, or
+  db_file: "metadata/oidc_clients.json" # optional: read oidc clients from json formatted file, will not persist dynamically registered clients!
   provider:
     client_registration_supported: Yes
     response_types_supported: ["code", "id_token token"]


### PR DESCRIPTION
Convenient way to pre-populate OIDC clients from readable json formatted file, instead of inserting records in MongoDB or dynamic registration. __setitem__, __delitem__ and pop are honoured but will not persist.