### PR TITLE
set default accepted time diff, because pysaml2 would set it 0 otherwise

### DIFF
--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -13,6 +13,7 @@ config:
       local: [idp.xml]
 
     entityid: <base_url>/<name>/proxy_saml2_backend.xml
+    accepted_time_diff: 60
     service:
       sp:
         want_response_signed: true

--- a/example/plugins/frontends/saml2_frontend.yaml.example
+++ b/example/plugins/frontends/saml2_frontend.yaml.example
@@ -12,6 +12,7 @@ config:
       local: [sp.xml]
 
     entityid: <base_url>/<name>/proxy.xml
+    accepted_time_diff: 60
     service:
       idp:
         endpoints:


### PR DESCRIPTION
Not setting it makes a configuration to rare  authentication failures if clocks are synchronized well below a second.