### PR TITLE
Add support for static client DB configuration

### DIFF
--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -3,6 +3,7 @@ name: OIDC
 config:
   signing_key_path: frontend.key
   db_uri: mongodb://db.example.com # optional: only support MongoDB, will default to in-memory storage if not specified
+  client_db_path: /path/to/your/cdb.json
   provider:
     client_registration_supported: Yes
     response_types_supported: ["code", "id_token token"]

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -78,11 +78,11 @@ class OpenIDConnectFrontend(FrontendModule):
 
         authz_state = self._init_authorization_state()
         db_uri = self.config.get("db_uri")
-        cdb_file = self.config.get("db_file")
+        cdb_file = self.config.get("client_db_path")
         if db_uri:
             cdb = MongoWrapper(db_uri, "satosa", "clients")
         elif cdb_file:
-            with open(self.config['client_db_path']) as f:
+            with open(cdb_file) as f:
                 cdb = json.loads(f.read())
         else:
             cdb = {}

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -78,7 +78,14 @@ class OpenIDConnectFrontend(FrontendModule):
 
         authz_state = self._init_authorization_state()
         db_uri = self.config.get("db_uri")
-        cdb = MongoWrapper(db_uri, "satosa", "clients") if db_uri else {}
+        cdb_file = self.config.get("db_file")
+        if db_uri:
+            cdb = MongoWrapper(db_uri, "satosa", "clients")
+        elif cdb_file:
+            with open(self.config['client_db_path']) as f:
+                cdb = json.loads(f.read())
+        else:
+            cdb = {}
         self.user_db = MongoWrapper(db_uri, "satosa", "authz_codes") if db_uri else {}
         self.provider = Provider(self.signing_key, capabilities, authz_state, cdb, Userinfo(self.user_db))
 


### PR DESCRIPTION
As it is now it's not easy for a deployer to use SATOSA in a setup where dynamic registration is not supported and the clients are/should be statically defined. This PR allows for this and resolves #152 